### PR TITLE
Removed "pr: none" parameter from azure-pipelines.yml 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,8 +4,6 @@ trigger:
     include:
       - "*"
 
-pr: none
-
 resources:
   repositories:
   - repository: self


### PR DESCRIPTION
Removed "pr: none" parameter from azure-pipelines.yml to allow PR builds as requested by Dan Beavon and Roy Bailey with regards to SonarCloud branch monitoring functionality