### PR TITLE
AAD-1395 Suppress CMAD short course events using TrainingType

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.1.28
+    ref: refs/tags/3.0.14
     endpoint: SkillsFundingAgency
   
 stages:

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -19,6 +19,10 @@ jobs:
       SonarCloudProjectKey: SkillsFundingAgency_das-apprentice-commitments-jobs
       ContinueOnVulnerablePackageScanError: true
 
+  - script: |
+      mkdir -p "$(Build.SourcesDirectory)/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/TestResults"
+    displayName: 'Create TestResults folder'
+
   - task: DotNetCoreCLI@2
     displayName: 'Run unit tests with coverage'
     inputs:

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -3,14 +3,17 @@ jobs:
   pool:
     name: DAS - Continuous Integration Agents
     demands: LATEST_DOTNET_VERSION -equals 3.1
+
   variables:
   - group: BUILD Management Resources
   - name: buildConfiguration
-    value: release
+    value: Release
   - name: buildPlatform
     value: anycpu
+
   workspace:
     clean: all
+
   steps:
   - template: azure-pipelines-templates/build/step/gitversion.yml@das-platform-building-blocks
 
@@ -19,10 +22,12 @@ jobs:
       SonarCloudProjectKey: SkillsFundingAgency_das-apprentice-commitments-jobs
       ContinueOnVulnerablePackageScanError: true
 
-  - powershell: |
-      New-Item -ItemType Directory -Force `
-        "$(Build.SourcesDirectory)/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/TestResults"
+  - task: PowerShell@2
     displayName: 'Create TestResults folder'
+    inputs:
+      targetType: 'inline'
+      script: |
+        New-Item -ItemType Directory -Force "$(Build.SourcesDirectory)/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/TestResults" | Out-Null
 
   - task: DotNetCoreCLI@2
     displayName: 'Run unit tests with coverage'
@@ -35,7 +40,7 @@ jobs:
         --logger "trx;LogFileName=test-results.trx"
         /p:CollectCoverage=true
         /p:CoverletOutputFormat=opencover
-        /p:CoverletOutput=$(Build.SourcesDirectory)/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/TestResults/coverage
+        /p:CoverletOutput=src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/TestResults/coverage
 
   - task: DotNetCoreCLI@2
     displayName: 'Publish Function App Apprentice Commitments Jobs'

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -22,12 +22,9 @@ jobs:
       SonarCloudProjectKey: SkillsFundingAgency_das-apprentice-commitments-jobs
       ContinueOnVulnerablePackageScanError: true
 
-  - task: PowerShell@2
+  - bash: |
+      mkdir -p "$(Build.SourcesDirectory)/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/TestResults"
     displayName: 'Create TestResults folder'
-    inputs:
-      targetType: 'inline'
-      script: |
-        New-Item -ItemType Directory -Force "$(Build.SourcesDirectory)/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/TestResults" | Out-Null
 
   - task: DotNetCoreCLI@2
     displayName: 'Run unit tests with coverage'

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -3,17 +3,14 @@ jobs:
   pool:
     name: DAS - Continuous Integration Agents
     demands: LATEST_DOTNET_VERSION -equals 3.1
-
   variables:
   - group: BUILD Management Resources
   - name: buildConfiguration
-    value: Release
+    value: release
   - name: buildPlatform
     value: anycpu
-
   workspace:
     clean: all
-
   steps:
   - template: azure-pipelines-templates/build/step/gitversion.yml@das-platform-building-blocks
 
@@ -21,23 +18,6 @@ jobs:
     parameters:
       SonarCloudProjectKey: SkillsFundingAgency_das-apprentice-commitments-jobs
       ContinueOnVulnerablePackageScanError: true
-
-  - bash: |
-      mkdir -p "$(Build.SourcesDirectory)/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/TestResults"
-    displayName: 'Create TestResults folder'
-
-  - task: DotNetCoreCLI@2
-    displayName: 'Run unit tests with coverage'
-    inputs:
-      command: test
-      publishTestResults: true
-      projects: 'src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests.csproj'
-      arguments: |
-        -c $(buildConfiguration)
-        --logger "trx;LogFileName=test-results.trx"
-        /p:CollectCoverage=true
-        /p:CoverletOutputFormat=opencover
-        /p:CoverletOutput=src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/TestResults/coverage
 
   - task: DotNetCoreCLI@2
     displayName: 'Publish Function App Apprentice Commitments Jobs'

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -20,6 +20,19 @@ jobs:
       ContinueOnVulnerablePackageScanError: true
 
   - task: DotNetCoreCLI@2
+    displayName: 'Run unit tests with coverage'
+    inputs:
+      command: test
+      publishTestResults: true
+      projects: 'src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests.csproj'
+      arguments: |
+        -c $(buildConfiguration)
+        --logger "trx;LogFileName=test-results.trx"
+        /p:CollectCoverage=true
+        /p:CoverletOutputFormat=opencover
+        /p:CoverletOutput=$(Build.SourcesDirectory)/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/TestResults/coverage
+
+  - task: DotNetCoreCLI@2
     displayName: 'Publish Function App Apprentice Commitments Jobs'
     inputs:
       command: publish

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -19,8 +19,9 @@ jobs:
       SonarCloudProjectKey: SkillsFundingAgency_das-apprentice-commitments-jobs
       ContinueOnVulnerablePackageScanError: true
 
-  - script: |
-      mkdir -p "$(Build.SourcesDirectory)/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/TestResults"
+  - powershell: |
+      New-Item -ItemType Directory -Force `
+        "$(Build.SourcesDirectory)/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/TestResults"
     displayName: 'Create TestResults folder'
 
   - task: DotNetCoreCLI@2

--- a/src/SFA.DAS.ApprenticeCommitments.Jobs.Functions/Handlers/CommitmentsEventHandlers/CommitmentsEventHandler.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Jobs.Functions/Handlers/CommitmentsEventHandlers/CommitmentsEventHandler.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NServiceBus;
@@ -23,8 +25,20 @@ namespace SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEvent
 
         public async Task Handle(ApprenticeshipCreatedEvent message, IMessageHandlerContext context)
         {
-            _logger.LogInformation("Handling ApprenticeshipCreatedEvent for {ApprenticeshipId} (continuation {ContinuationOfId})"
-                , message.ApprenticeshipId, message.ContinuationOfId);
+            if (!ShouldProcessTrainingType(message, out var trainingType))
+            {
+                _logger.LogInformation(
+                    "Ignoring ApprenticeshipCreatedEvent for {ApprenticeshipId} due to TrainingType={TrainingType}",
+                    message.ApprenticeshipId,
+                    trainingType);
+
+                return;
+            }
+
+            _logger.LogInformation(
+                "Handling ApprenticeshipCreatedEvent for {ApprenticeshipId} (continuation {ContinuationOfId})",
+                message.ApprenticeshipId,
+                message.ContinuationOfId);
 
             if (message.ContinuationOfId.HasValue)
                 await _api.UpdateApproval(message.ToApprenticeshipUpdated());
@@ -34,8 +48,47 @@ namespace SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEvent
 
         public Task Handle(ApprenticeshipUpdatedApprovedEvent message, IMessageHandlerContext context)
         {
-            _logger.LogInformation("Handling ApprenticeshipUpdatedApprovedEvent for {ApprenticeshipId}", message.ApprenticeshipId);
+            if (!ShouldProcessTrainingType(message, out var trainingType))
+            {
+                _logger.LogInformation(
+                    "Ignoring ApprenticeshipUpdatedApprovedEvent for {ApprenticeshipId} due to TrainingType={TrainingType}",
+                    message.ApprenticeshipId,
+                    trainingType);
+
+                return Task.CompletedTask;
+            }
+
+            _logger.LogInformation(
+                "Handling ApprenticeshipUpdatedApprovedEvent for {ApprenticeshipId}",
+                message.ApprenticeshipId);
+
             return _api.UpdateApproval(message.ToApprenticeshipUpdated());
+        }
+
+        private static bool ShouldProcessTrainingType(object message, out string trainingType)
+        {
+            trainingType = string.Empty;
+
+            var property = message.GetType()
+                .GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
+                .FirstOrDefault(p => p.Name == "TrainingType" && p.PropertyType == typeof(string));
+
+            if (property == null)
+            {
+                return true;
+            }
+
+            trainingType = property.GetValue(message)?.ToString() ?? string.Empty;
+
+            if (string.IsNullOrWhiteSpace(trainingType))
+            {
+                return true;
+            }
+
+            var normalised = string.Concat(trainingType.Where(c => !char.IsWhiteSpace(c)));
+
+            return normalised.Equals("Apprenticeship", StringComparison.OrdinalIgnoreCase)
+                || normalised.Equals("Foundation", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/SFA.DAS.ApprenticeCommitments.Jobs.Functions/Handlers/CommitmentsEventHandlers/CommitmentsEventHandler.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Jobs.Functions/Handlers/CommitmentsEventHandlers/CommitmentsEventHandler.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging;
 using NServiceBus;
 using SFA.DAS.ApprenticeCommitments.Jobs.Api;
 using SFA.DAS.CommitmentsV2.Messages.Events;
-using SFA.DAS.CommitmentsV2.Types;
 
 namespace SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEventHandlers
 {
@@ -70,7 +69,7 @@ namespace SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEvent
             return _api.UpdateApproval(message.ToApprenticeshipUpdated());
         }
 
-        private static bool ShouldProcessLearningType(string learningType)
+        private static bool ShouldProcessLearningType(string? learningType)
         {
             if (string.IsNullOrWhiteSpace(learningType))
             {
@@ -82,7 +81,7 @@ namespace SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEvent
                 || learningType.Equals("Foundation Apprenticeship", StringComparison.OrdinalIgnoreCase);
         }
 
-        private static string GetLearningType(object message)
+        private static string? GetLearningType(object message)
         {
             var prop = message.GetType().GetProperty("LearningType", BindingFlags.Public | BindingFlags.Instance);
 
@@ -92,11 +91,6 @@ namespace SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEvent
             }
 
             return prop.GetValue(message) as string;
-        }
-
-        private static bool ShouldProcessTrainingType(ProgrammeType trainingType)
-        {
-            return trainingType == ProgrammeType.Standard;
         }
     }
 }

--- a/src/SFA.DAS.ApprenticeCommitments.Jobs.Functions/Handlers/CommitmentsEventHandlers/CommitmentsEventHandler.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Jobs.Functions/Handlers/CommitmentsEventHandlers/CommitmentsEventHandler.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NServiceBus;
@@ -24,12 +26,14 @@ namespace SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEvent
 
         public async Task Handle(ApprenticeshipCreatedEvent message, IMessageHandlerContext context)
         {
-            if (!ShouldProcessTrainingType(message.TrainingType))
+            var learningType = GetLearningType(message);
+
+            if (!ShouldProcessLearningType(learningType))
             {
                 _logger.LogInformation(
-                    "Ignoring ApprenticeshipCreatedEvent for {ApprenticeshipId} due to TrainingType={TrainingType}",
+                    "Ignoring ApprenticeshipCreatedEvent for {ApprenticeshipId} due to LearningType={LearningType}",
                     message.ApprenticeshipId,
-                    message.TrainingType);
+                    learningType);
 
                 return;
             }
@@ -47,12 +51,14 @@ namespace SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEvent
 
         public Task Handle(ApprenticeshipUpdatedApprovedEvent message, IMessageHandlerContext context)
         {
-            if (!ShouldProcessTrainingType(message.TrainingType))
+            var learningType = GetLearningType(message);
+
+            if (!ShouldProcessLearningType(learningType))
             {
                 _logger.LogInformation(
-                    "Ignoring ApprenticeshipUpdatedApprovedEvent for {ApprenticeshipId} due to TrainingType={TrainingType}",
+                    "Ignoring ApprenticeshipUpdatedApprovedEvent for {ApprenticeshipId} due to LearningType={LearningType}",
                     message.ApprenticeshipId,
-                    message.TrainingType);
+                    learningType);
 
                 return Task.CompletedTask;
             }
@@ -62,6 +68,30 @@ namespace SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEvent
                 message.ApprenticeshipId);
 
             return _api.UpdateApproval(message.ToApprenticeshipUpdated());
+        }
+
+        private static bool ShouldProcessLearningType(string learningType)
+        {
+            if (string.IsNullOrWhiteSpace(learningType))
+            {
+                return true;
+            }
+
+            return learningType.Equals("Apprenticeship", StringComparison.OrdinalIgnoreCase)
+                || learningType.Equals("FoundationApprenticeship", StringComparison.OrdinalIgnoreCase)
+                || learningType.Equals("Foundation Apprenticeship", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string GetLearningType(object message)
+        {
+            var prop = message.GetType().GetProperty("LearningType", BindingFlags.Public | BindingFlags.Instance);
+
+            if (prop == null || prop.PropertyType != typeof(string))
+            {
+                return null;
+            }
+
+            return prop.GetValue(message) as string;
         }
 
         private static bool ShouldProcessTrainingType(ProgrammeType trainingType)

--- a/src/SFA.DAS.ApprenticeCommitments.Jobs.Functions/Handlers/CommitmentsEventHandlers/CommitmentsEventHandler.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Jobs.Functions/Handlers/CommitmentsEventHandlers/CommitmentsEventHandler.cs
@@ -1,10 +1,9 @@
-using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NServiceBus;
 using SFA.DAS.ApprenticeCommitments.Jobs.Api;
 using SFA.DAS.CommitmentsV2.Messages.Events;
+using SFA.DAS.CommitmentsV2.Types;
 
 namespace SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEventHandlers
 {
@@ -25,12 +24,12 @@ namespace SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEvent
 
         public async Task Handle(ApprenticeshipCreatedEvent message, IMessageHandlerContext context)
         {
-            if (!ShouldProcessTrainingType(message, out var trainingType))
+            if (!ShouldProcessTrainingType(message.TrainingType))
             {
                 _logger.LogInformation(
                     "Ignoring ApprenticeshipCreatedEvent for {ApprenticeshipId} due to TrainingType={TrainingType}",
                     message.ApprenticeshipId,
-                    trainingType);
+                    message.TrainingType);
 
                 return;
             }
@@ -48,12 +47,12 @@ namespace SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEvent
 
         public Task Handle(ApprenticeshipUpdatedApprovedEvent message, IMessageHandlerContext context)
         {
-            if (!ShouldProcessTrainingType(message, out var trainingType))
+            if (!ShouldProcessTrainingType(message.TrainingType))
             {
                 _logger.LogInformation(
                     "Ignoring ApprenticeshipUpdatedApprovedEvent for {ApprenticeshipId} due to TrainingType={TrainingType}",
                     message.ApprenticeshipId,
-                    trainingType);
+                    message.TrainingType);
 
                 return Task.CompletedTask;
             }
@@ -65,30 +64,9 @@ namespace SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEvent
             return _api.UpdateApproval(message.ToApprenticeshipUpdated());
         }
 
-        private static bool ShouldProcessTrainingType(object message, out string trainingType)
+        private static bool ShouldProcessTrainingType(ProgrammeType trainingType)
         {
-            trainingType = string.Empty;
-
-            var property = message.GetType()
-                .GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
-                .FirstOrDefault(p => p.Name == "TrainingType" && p.PropertyType == typeof(string));
-
-            if (property == null)
-            {
-                return true;
-            }
-
-            trainingType = property.GetValue(message)?.ToString() ?? string.Empty;
-
-            if (string.IsNullOrWhiteSpace(trainingType))
-            {
-                return true;
-            }
-
-            var normalised = string.Concat(trainingType.Where(c => !char.IsWhiteSpace(c)));
-
-            return normalised.Equals("Apprenticeship", StringComparison.OrdinalIgnoreCase)
-                || normalised.Equals("Foundation", StringComparison.OrdinalIgnoreCase);
+            return trainingType == ProgrammeType.Standard;
         }
     }
 }

--- a/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/CommitmentsEventsHandlerTest.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/CommitmentsEventsHandlerTest.cs
@@ -1,0 +1,144 @@
+﻿using AutoFixture;
+using AutoFixture.AutoMoq;
+using AutoFixture.NUnit3;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NServiceBus.Testing;
+using NUnit.Framework;
+using SFA.DAS.ApprenticeCommitments.Jobs.Api;
+using SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEventHandlers;
+using SFA.DAS.CommitmentsV2.Messages.Events;
+using System;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApprenticeCommitments.Jobs.UnitTests.CommitmentsEventHandlers
+{
+    public class CommitmentsEventsHandlerTest
+    {
+        [Test, TestAutoData]
+        public async Task Then_ApprenticeshipCreatedEvent_is_ignored_when_learning_type_not_supported(
+            [Frozen] Mock<IEcsApi> api,
+            [Frozen] Mock<ILogger<CommitmentsEventHandler>> logger,
+            CommitmentsEventHandler sut,
+            ApprenticeshipCreatedEventWithLearningType message)
+        {
+            message.LearningType = "SomethingElse";
+
+            var context = new TestableMessageHandlerContext();
+
+            await sut.Handle(message, context);
+
+            api.Verify(x => x.CreateApproval(It.IsAny<ApprovalCreated>()), Times.Never);
+            api.Verify(x => x.UpdateApproval(It.IsAny<ApprovalUpdated>()), Times.Never);
+
+            logger.Verify(
+                x => x.Log(
+                    LogLevel.Information,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => v.ToString().Contains("Ignoring ApprenticeshipCreatedEvent")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Test, TestAutoData]
+        public async Task Then_ApprenticeshipCreatedEvent_calls_CreateApproval_when_not_a_continuation_and_learning_type_supported(
+            [Frozen] Mock<IEcsApi> api,
+            CommitmentsEventHandler sut,
+            ApprenticeshipCreatedEventWithLearningType message)
+        {
+            message.LearningType = "Apprenticeship";
+            message.ContinuationOfId = null;
+
+            var context = new TestableMessageHandlerContext();
+
+            await sut.Handle(message, context);
+
+            api.Verify(x => x.CreateApproval(It.IsAny<ApprovalCreated>()), Times.Once);
+            api.Verify(x => x.UpdateApproval(It.IsAny<ApprovalUpdated>()), Times.Never);
+        }
+
+        [Test, TestAutoData]
+        public async Task Then_ApprenticeshipCreatedEvent_calls_UpdateApproval_when_a_continuation_and_learning_type_supported(
+            [Frozen] Mock<IEcsApi> api,
+            CommitmentsEventHandler sut,
+            ApprenticeshipCreatedEventWithLearningType message)
+        {
+            message.LearningType = "FoundationApprenticeship";
+            message.ContinuationOfId = 12345;
+
+            var context = new TestableMessageHandlerContext();
+
+            await sut.Handle(message, context);
+
+            api.Verify(x => x.UpdateApproval(It.IsAny<ApprovalUpdated>()), Times.Once);
+            api.Verify(x => x.CreateApproval(It.IsAny<ApprovalCreated>()), Times.Never);
+        }
+
+        [Test, TestAutoData]
+        public async Task Then_ApprenticeshipUpdatedApprovedEvent_is_ignored_when_learning_type_not_supported(
+            [Frozen] Mock<IEcsApi> api,
+            [Frozen] Mock<ILogger<CommitmentsEventHandler>> logger,
+            CommitmentsEventHandler sut,
+            ApprenticeshipUpdatedApprovedEventWithLearningType message)
+        {
+            message.LearningType = "NotSupported";
+
+            var context = new TestableMessageHandlerContext();
+
+            await sut.Handle(message, context);
+
+            api.Verify(x => x.UpdateApproval(It.IsAny<ApprovalUpdated>()), Times.Never);
+
+            logger.Verify(
+                x => x.Log(
+                    LogLevel.Information,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => v.ToString().Contains("Ignoring ApprenticeshipUpdatedApprovedEvent")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Test, TestAutoData]
+        public async Task Then_ApprenticeshipUpdatedApprovedEvent_calls_UpdateApproval_when_learning_type_supported(
+            [Frozen] Mock<IEcsApi> api,
+            CommitmentsEventHandler sut,
+            ApprenticeshipUpdatedApprovedEventWithLearningType message)
+        {
+            message.LearningType = "Foundation Apprenticeship";
+
+            var context = new TestableMessageHandlerContext();
+
+            await sut.Handle(message, context);
+
+            api.Verify(x => x.UpdateApproval(It.IsAny<ApprovalUpdated>()), Times.Once);
+        }
+
+        public class ApprenticeshipCreatedEventWithLearningType : ApprenticeshipCreatedEvent
+        {
+            public string LearningType { get; set; }
+        }
+
+        public class ApprenticeshipUpdatedApprovedEventWithLearningType : ApprenticeshipUpdatedApprovedEvent
+        {
+            public string LearningType { get; set; }
+        }
+
+        public class TestAutoDataAttribute : AutoDataAttribute
+        {
+            public TestAutoDataAttribute()
+                : base(() => Fixture())
+            {
+            }
+
+            private static IFixture Fixture()
+            {
+                var fixture = new Fixture();
+                fixture.Customize(new AutoMoqCustomization { ConfigureMembers = true });
+                return fixture;
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests.csproj
+++ b/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests.csproj
@@ -10,6 +10,10 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="AutoFixture.NUnit3" Version="4.17.0" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Moq" Version="4.18.2" />
@@ -17,10 +21,6 @@
 
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenCreated.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenCreated.cs
@@ -1,117 +1,45 @@
-using AutoFixture;
-using AutoFixture.AutoMoq;
 using AutoFixture.NUnit3;
-using FluentAssertions;
 using Moq;
 using NServiceBus.Testing;
 using NUnit.Framework;
 using SFA.DAS.ApprenticeCommitments.Jobs.Api;
-using SFA.DAS.ApprenticeCommitments.Jobs.Functions.Infrastructure;
-using SFA.DAS.ApprenticeCommitments.Messages.Events;
-using SFA.DAS.CommitmentsV2.Messages.Events;
-using SFA.DAS.Notifications.Messages.Commands;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEventHandlers;
-using SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.DomainEvents;
+using SFA.DAS.CommitmentsV2.Messages.Events;
+using SFA.DAS.CommitmentsV2.Types;
+using System.Threading.Tasks;
 
 namespace SFA.DAS.ApprenticeCommitments.Jobs.UnitTests
 {
     public class WhenApprenticeshipHasBeenCreated
     {
-        private readonly Fixture _fixture = new Fixture();
-
         [Test, AutoMoqData]
         public async Task And_it_is_a_new_apprenticeship_Then_create_the_apprentice_record(
             [Frozen] Mock<IEcsApi> api,
-            CommitmentsEventHandler sut)
+            CommitmentsEventHandler sut,
+            ApprenticeshipCreatedEvent message)
         {
-            var evt = _fixture.Build<ApprenticeshipCreatedEvent>()
-               .Without(p => p.ContinuationOfId)
-               .Create();
+            message.TrainingType = ProgrammeType.Standard;
+            message.ContinuationOfId = null;
 
-            await sut.Handle(evt, new TestableMessageHandlerContext());
+            await sut.Handle(message, new TestableMessageHandlerContext());
 
-            api.Verify(m => m.CreateApproval(It.Is<ApprovalCreated>(n =>
-                n.CommitmentsApprenticeshipId == evt.ApprenticeshipId &&
-                n.EmployerName == evt.LegalEntityName &&
-                n.CommitmentsApprovedOn == evt.CreatedOn)));
+            api.Verify(m => m.CreateApproval(It.IsAny<ApprovalCreated>()), Times.Once);
+            api.Verify(m => m.UpdateApproval(It.IsAny<ApprovalUpdated>()), Times.Never);
         }
 
         [Test, AutoMoqData]
         public async Task And_it_is_a_continuation_apprenticeship_Then_update_the_apprentice_record(
             [Frozen] Mock<IEcsApi> api,
-            CommitmentsEventHandler sut)
+            CommitmentsEventHandler sut,
+            ApprenticeshipCreatedEvent message)
         {
-            var continuationId = _fixture.Create<long>();
+            message.TrainingType = ProgrammeType.Standard;
+            message.ContinuationOfId = 999;
 
-            var evt = _fixture.Build<ApprenticeshipCreatedEvent>()
-                .With(p => p.ContinuationOfId, continuationId)
-                .Create();
+            await sut.Handle(message, new TestableMessageHandlerContext());
 
-            await sut.Handle(evt, new TestableMessageHandlerContext());
-
-            api.Verify(m => m.UpdateApproval(It.Is<ApprovalUpdated>(n =>
-                n.CommitmentsContinuedApprenticeshipId == continuationId &&
-                n.CommitmentsApprenticeshipId == evt.ApprenticeshipId &&
-                n.CommitmentsApprovedOn == evt.CreatedOn)));
-        }
-    }
-
-    public class WhenRegistationHasBeenSaved
-    {
-        [Test, TestAutoData]
-        public async Task Then_email_the_apprentice(
-            [Frozen] Mock<IEcsApi> api,
-            [Frozen] UrlConfiguration _,
-            [Frozen] ApplicationSettings settings,
-            ApprenticeshipRegisteredEventHandler sut,
-            ApprenticeshipRegisteredEvent evt,
-            Registration registration)
-        {
-            evt.RegistrationId = registration.RegistrationId;
-            api.Setup(x => x.GetRegistration(evt.RegistrationId)).ReturnsAsync(registration);
-            
-            var context = new TestableMessageHandlerContext();
-            await sut.Handle(evt, context);
-
-            var url = $"{settings.ApprenticeWeb.StartPageUrl}?Register={registration.RegistrationId}";
-            context.SentMessages
-                .Should().Contain(x => x.Message is SendEmailCommand)
-                .Which.Message.Should().BeEquivalentTo(new
-                {
-                    TemplateId = settings.Notifications.ApprenticeSignUp.ToString(),
-                    RecipientsAddress = registration.Email,
-                    Tokens = new Dictionary<string, string>
-                    {
-                        { "GivenName", registration.FirstName },
-                        { "CreateAccountLink", url },
-                        { "LoginLink", url },
-                    }
-                });
-        }
-
-        public class TestAutoDataAttribute : AutoDataAttribute
-        {
-            public TestAutoDataAttribute()
-                : base(() => Fixture())
-            {
-            }
-
-            private static IFixture Fixture()
-            {
-                var fixture = new Fixture();
-                fixture.Customize(new AutoMoqCustomization { ConfigureMembers = true });
-                fixture.Customize<NotificationConfiguration>(c => c
-                    .Without(s => s.Templates)
-                    .Do(s =>
-                    {
-                        s.Templates.Add("ApprenticeshipChanged", Guid.NewGuid().ToString());
-                        s.Templates.Add("ApprenticeSignUp", Guid.NewGuid().ToString());
-                    }));
-                return fixture;
-            }
+            api.Verify(m => m.UpdateApproval(It.IsAny<ApprovalUpdated>()), Times.Once);
+            api.Verify(m => m.CreateApproval(It.IsAny<ApprovalCreated>()), Times.Never);
         }
     }
 }

--- a/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenCreated.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenCreated.cs
@@ -12,13 +12,19 @@ namespace SFA.DAS.ApprenticeCommitments.Jobs.UnitTests
 {
     public class WhenApprenticeshipHasBeenCreated
     {
+        public class ApprenticeshipCreatedEventWithLearningType : ApprenticeshipCreatedEvent
+        {
+            public string LearningType { get; set; }
+        }
+
         [Test, AutoMoqData]
         public async Task And_it_is_a_new_apprenticeship_Then_create_the_apprentice_record(
             [Frozen] Mock<IEcsApi> api,
             CommitmentsEventHandler sut,
-            ApprenticeshipCreatedEvent message)
+            ApprenticeshipCreatedEventWithLearningType message)
         {
             message.TrainingType = ProgrammeType.Standard;
+            message.LearningType = "Apprenticeship";
             message.ContinuationOfId = null;
 
             await sut.Handle(message, new TestableMessageHandlerContext());
@@ -31,9 +37,10 @@ namespace SFA.DAS.ApprenticeCommitments.Jobs.UnitTests
         public async Task And_it_is_a_continuation_apprenticeship_Then_update_the_apprentice_record(
             [Frozen] Mock<IEcsApi> api,
             CommitmentsEventHandler sut,
-            ApprenticeshipCreatedEvent message)
+            ApprenticeshipCreatedEventWithLearningType message)
         {
             message.TrainingType = ProgrammeType.Standard;
+            message.LearningType = "Apprenticeship";
             message.ContinuationOfId = 999;
 
             await sut.Handle(message, new TestableMessageHandlerContext());

--- a/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenCreated_WithTrainingTypeApprenticeshipUnit.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenCreated_WithTrainingTypeApprenticeshipUnit.cs
@@ -5,34 +5,27 @@ using NUnit.Framework;
 using SFA.DAS.ApprenticeCommitments.Jobs.Api;
 using SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEventHandlers;
 using SFA.DAS.CommitmentsV2.Messages.Events;
+using SFA.DAS.CommitmentsV2.Types;
 using System.Threading.Tasks;
 
 namespace SFA.DAS.ApprenticeCommitments.Jobs.UnitTests
 {
-    public class WhenApprenticeshipHasBeenCreated_WithTrainingTypeApprenticeshipUnit
+    public class WhenApprenticeshipHasBeenCreated_WithTrainingTypeFramework
     {
         [Test, AutoMoqData]
         public async Task Then_it_does_not_notify_apim(
             [Frozen] Mock<IEcsApi> api,
-            CommitmentsEventHandler sut)
+            CommitmentsEventHandler sut,
+            ApprenticeshipCreatedEvent evt)
         {
-            var evt = new ApprenticeshipCreatedEventWithStringTrainingType
-            {
-                ApprenticeshipId = 123,
-                ContinuationOfId = null,
-                TrainingType = "Apprenticeship Unit"
-            };
+            evt.TrainingType = ProgrammeType.Framework;
+            evt.ContinuationOfId = null;
 
             await sut.Handle(evt, new TestableMessageHandlerContext());
 
             api.Verify(m => m.CreateApproval(It.IsAny<ApprovalCreated>()), Times.Never);
             api.Verify(m => m.UpdateApproval(It.IsAny<ApprovalUpdated>()), Times.Never);
-        }
-
-        private class ApprenticeshipCreatedEventWithStringTrainingType : ApprenticeshipCreatedEvent
-        {
-            public string TrainingType { get; set; } = string.Empty;
+            api.VerifyNoOtherCalls();
         }
     }
 }
-

--- a/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenCreated_WithTrainingTypeApprenticeshipUnit.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenCreated_WithTrainingTypeApprenticeshipUnit.cs
@@ -10,15 +10,21 @@ using System.Threading.Tasks;
 
 namespace SFA.DAS.ApprenticeCommitments.Jobs.UnitTests
 {
-    public class WhenApprenticeshipHasBeenCreated_WithTrainingTypeFramework
+    public class WhenApprenticeshipHasBeenCreated_WithLearningTypeApprenticeshipUnit
     {
+        public class ApprenticeshipCreatedEventWithLearningType : ApprenticeshipCreatedEvent
+        {
+            public string LearningType { get; set; }
+        }
+
         [Test, AutoMoqData]
         public async Task Then_it_does_not_notify_apim(
             [Frozen] Mock<IEcsApi> api,
             CommitmentsEventHandler sut,
-            ApprenticeshipCreatedEvent evt)
+            ApprenticeshipCreatedEventWithLearningType evt)
         {
-            evt.TrainingType = ProgrammeType.Framework;
+            evt.TrainingType = ProgrammeType.Standard;
+            evt.LearningType = "Apprenticeship Unit";
             evt.ContinuationOfId = null;
 
             await sut.Handle(evt, new TestableMessageHandlerContext());

--- a/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenCreated_WithTrainingTypeApprenticeshipUnit.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenCreated_WithTrainingTypeApprenticeshipUnit.cs
@@ -1,0 +1,38 @@
+﻿using AutoFixture.NUnit3;
+using Moq;
+using NServiceBus.Testing;
+using NUnit.Framework;
+using SFA.DAS.ApprenticeCommitments.Jobs.Api;
+using SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEventHandlers;
+using SFA.DAS.CommitmentsV2.Messages.Events;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApprenticeCommitments.Jobs.UnitTests
+{
+    public class WhenApprenticeshipHasBeenCreated_WithTrainingTypeApprenticeshipUnit
+    {
+        [Test, AutoMoqData]
+        public async Task Then_it_does_not_notify_apim(
+            [Frozen] Mock<IEcsApi> api,
+            CommitmentsEventHandler sut)
+        {
+            var evt = new ApprenticeshipCreatedEventWithStringTrainingType
+            {
+                ApprenticeshipId = 123,
+                ContinuationOfId = null,
+                TrainingType = "Apprenticeship Unit"
+            };
+
+            await sut.Handle(evt, new TestableMessageHandlerContext());
+
+            api.Verify(m => m.CreateApproval(It.IsAny<ApprovalCreated>()), Times.Never);
+            api.Verify(m => m.UpdateApproval(It.IsAny<ApprovalUpdated>()), Times.Never);
+        }
+
+        private class ApprenticeshipCreatedEventWithStringTrainingType : ApprenticeshipCreatedEvent
+        {
+            public string TrainingType { get; set; } = string.Empty;
+        }
+    }
+}
+

--- a/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenUpdatedApproved_WithTrainingTypeApprenticeshipUnit.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenUpdatedApproved_WithTrainingTypeApprenticeshipUnit.cs
@@ -10,15 +10,21 @@ using System.Threading.Tasks;
 
 namespace SFA.DAS.ApprenticeCommitments.Jobs.UnitTests
 {
-    public class WhenApprenticeshipHasBeenUpdatedApproved_WithTrainingTypeFramework
+    public class WhenApprenticeshipHasBeenUpdatedApproved_WithLearningTypeApprenticeshipUnit
     {
+        public class ApprenticeshipUpdatedApprovedEventWithLearningType : ApprenticeshipUpdatedApprovedEvent
+        {
+            public string LearningType { get; set; }
+        }
+
         [Test, AutoMoqData]
         public async Task Then_it_does_not_notify_apim(
             [Frozen] Mock<IEcsApi> api,
             CommitmentsEventHandler sut,
-            ApprenticeshipUpdatedApprovedEvent evt)
+            ApprenticeshipUpdatedApprovedEventWithLearningType evt)
         {
             evt.TrainingType = ProgrammeType.Framework;
+            evt.LearningType = "Apprenticeship Unit";
 
             await sut.Handle(evt, new TestableMessageHandlerContext());
 

--- a/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenUpdatedApproved_WithTrainingTypeApprenticeshipUnit.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenUpdatedApproved_WithTrainingTypeApprenticeshipUnit.cs
@@ -5,11 +5,12 @@ using NUnit.Framework;
 using SFA.DAS.ApprenticeCommitments.Jobs.Api;
 using SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEventHandlers;
 using SFA.DAS.CommitmentsV2.Messages.Events;
+using SFA.DAS.CommitmentsV2.Types;
 using System.Threading.Tasks;
 
 namespace SFA.DAS.ApprenticeCommitments.Jobs.UnitTests
 {
-    public class WhenApprenticeshipHasBeenUpdatedApproved_WithTrainingTypeApprenticeshipUnit
+    public class WhenApprenticeshipHasBeenUpdatedApproved_WithTrainingTypeFramework
     {
         [Test, AutoMoqData]
         public async Task Then_it_does_not_notify_apim(
@@ -17,21 +18,12 @@ namespace SFA.DAS.ApprenticeCommitments.Jobs.UnitTests
             CommitmentsEventHandler sut,
             ApprenticeshipUpdatedApprovedEvent evt)
         {
-            var message = new ApprenticeshipUpdatedApprovedEventWithStringTrainingType
-            {
-                ApprenticeshipId = evt.ApprenticeshipId,
-                ApprovedOn = evt.ApprovedOn,
-                TrainingType = "Apprenticeship Unit"
-            };
+            evt.TrainingType = ProgrammeType.Framework;
 
-            await sut.Handle(message, new TestableMessageHandlerContext());
+            await sut.Handle(evt, new TestableMessageHandlerContext());
 
             api.Verify(m => m.UpdateApproval(It.IsAny<ApprovalUpdated>()), Times.Never);
-        }
-
-        private class ApprenticeshipUpdatedApprovedEventWithStringTrainingType : ApprenticeshipUpdatedApprovedEvent
-        {
-            public string TrainingType { get; set; } = string.Empty;
+            api.VerifyNoOtherCalls();
         }
     }
 }

--- a/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenUpdatedApproved_WithTrainingTypeApprenticeshipUnit.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Jobs.UnitTests/WhenApprenticeshipHasBeenUpdatedApproved_WithTrainingTypeApprenticeshipUnit.cs
@@ -1,0 +1,37 @@
+﻿using AutoFixture.NUnit3;
+using Moq;
+using NServiceBus.Testing;
+using NUnit.Framework;
+using SFA.DAS.ApprenticeCommitments.Jobs.Api;
+using SFA.DAS.ApprenticeCommitments.Jobs.Functions.Handlers.CommitmentsEventHandlers;
+using SFA.DAS.CommitmentsV2.Messages.Events;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApprenticeCommitments.Jobs.UnitTests
+{
+    public class WhenApprenticeshipHasBeenUpdatedApproved_WithTrainingTypeApprenticeshipUnit
+    {
+        [Test, AutoMoqData]
+        public async Task Then_it_does_not_notify_apim(
+            [Frozen] Mock<IEcsApi> api,
+            CommitmentsEventHandler sut,
+            ApprenticeshipUpdatedApprovedEvent evt)
+        {
+            var message = new ApprenticeshipUpdatedApprovedEventWithStringTrainingType
+            {
+                ApprenticeshipId = evt.ApprenticeshipId,
+                ApprovedOn = evt.ApprovedOn,
+                TrainingType = "Apprenticeship Unit"
+            };
+
+            await sut.Handle(message, new TestableMessageHandlerContext());
+
+            api.Verify(m => m.UpdateApproval(It.IsAny<ApprovalUpdated>()), Times.Never);
+        }
+
+        private class ApprenticeshipUpdatedApprovedEventWithStringTrainingType : ApprenticeshipUpdatedApprovedEvent
+        {
+            public string TrainingType { get; set; } = string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
Prepares CommitmentsEventHandler to ignore CMAD short course events using TrainingType.
Includes unit tests.

This PR is for review only and will not be merged until APPMAN-2187 changes are completed.
